### PR TITLE
[WIP] Introduce reftypes

### DIFF
--- a/asmcomp/wasm32/ast.ml
+++ b/asmcomp/wasm32/ast.ml
@@ -63,7 +63,7 @@ type mem_size = Mem8 | Mem16 | Mem32
 type extension = SX | ZX
 
 type 'a memop =
-  {ty : value_type; align : int; offset : int32; sz : 'a option}
+  {ty : num_type; align : int; offset : int32; sz : 'a option}
 type loadop = (mem_size * extension) memop
 type storeop = mem_size memop
 

--- a/asmcomp/wasm32/emit.mlp
+++ b/asmcomp/wasm32/emit.mlp
@@ -198,52 +198,16 @@ let fundecl ({fun_name; fun_args; fun_body; _}) =
   let rec to_operations expression_list operation = 
     let el = List.fold_left (fun a (e, _) -> a @ (emit_expr e)) [] expression_list in
     match operation, expression_list with
-    | Calloc, ((Tblockheader (header, _), _) as hd) :: rest -> (
-        let (_word_size, _tag) = blockheader_details header in
-        let counter = !unique_name_counter in
-        unique_name_counter := !unique_name_counter + 1;
-        let local_ = add_local ("allocate_memory_pointer_" ^ string_of_int counter, typ_int) in
-        let position = ref 0 in
-        let total_size = ref 0 in
-        let calls = List.fold_left (fun calls (f, rt) ->
-          let before = calls @
-          [GetLocal local_;
-          Const (I32 (I32.of_int_s !position));
-          Binary (I32 I32Op.Add)]
-          in        
-          let middle = match f with        
+    | Calloc, ((Tblockheader (_header, _), _) as hd) :: rest -> (
+        let top_to_wasm_instructions (typed_exp, _stack_typ) =
+          let eval_opcodes = match typed_exp with        
           | Tconst_symbol (symbol, Sfunction) -> [FuncSymbol symbol]
           | Tconst_symbol (symbol, Sdata) -> [DataSymbol symbol]
           | _ as e -> emit_expr e
           in
-          let add = match rt with 
-          | [NumType F32Type]
-          | [NumType I32Type] -> 4
-          | _ -> assert false
-          in
-          total_size := !total_size + add;
-          let result = match rt with
-            | NumType x::_ -> before @ middle @ [Store {ty = x; align = 0; offset = 0l; sz = None}]
-            | _ -> assert false
-          in
-          
-          position := !position + add;
-          result
-        ) [] ([hd] @ rest)
-        in  
-        let result = [Const (I32 (Int32.of_int !total_size));
-        Call "caml_alloc";
-        SetLocal local_
-        ]
-        @
-        calls
-        @    
-        [GetLocal local_;
-        Const (I32 4l);
-        Binary (I32 I32Op.Add)
-        ]
-        in 
-        result
+          eval_opcodes @ [ Call "js_int_new" ]
+        in
+        List.flatten (List.map top_to_wasm_instructions (hd::rest)) 
       )
     | Cmodi, [(fst, _); (snd, _)] ->
       let counter = !unique_name_counter in

--- a/asmcomp/wasm32/emit.mlp
+++ b/asmcomp/wasm32/emit.mlp
@@ -92,20 +92,20 @@ let begin_assembly () = (
     globals = [
       {
         name = "global_offset";
-        gtype = Types.GlobalType (Types.I32Type, Types.Mutable);
+        gtype = Types.GlobalType (Types.NumType Types.I32Type, Types.Mutable);
         value = [Const (I32 (I32.of_int_s !global_offset))]
       };
       {
         name = "global_memory_offset";
-        gtype = Types.GlobalType (Types.I32Type, Types.Mutable);
+        gtype = Types.GlobalType (Types.NumType Types.I32Type, Types.Mutable);
         value = [Const (I32 (I32.of_int_s 0))]
       }
     ];
     types = [
-      {tname = "jsTryWithType"; tdetails = Types.FuncType ([Types.I32Type;Types.I32Type;Types.I32Type], [])};
-      {tname = "type_"; tdetails = Types.FuncType ([Types.I32Type], [Types.I32Type])};
+      {tname = "jsTryWithType"; tdetails = Types.FuncType ([Types.NumType Types.I32Type;Types.NumType Types.I32Type;Types.NumType Types.I32Type], [])};
+      {tname = "type_"; tdetails = Types.FuncType ([Types.NumType Types.I32Type], [Types.NumType Types.I32Type])};
       {tname = "empty_type"; tdetails = Types.FuncType ([], [])};
-      {tname = "raise_i32_ftype"; tdetails = Types.FuncType ([Types.I32Type], [])}
+      {tname = "raise_i32_ftype"; tdetails = Types.FuncType ([Types.NumType Types.I32Type], [])}
     ];
     data =  [
       {
@@ -217,12 +217,14 @@ let fundecl ({fun_name; fun_args; fun_body; _}) =
           | _ as e -> emit_expr e
           in
           let add = match rt with 
-          | [F32Type]
-          | [I32Type] -> 4
+          | [NumType F32Type]
+          | [NumType I32Type] -> 4
           | _ -> assert false
           in
           total_size := !total_size + add;
-          let result = before @ middle @ [Store {ty = List.hd(rt); align = 0; offset = 0l; sz = None}]     
+          let result = match rt with
+            | NumType x::_ -> before @ middle @ [Store {ty = x; align = 0; offset = 0l; sz = None}]
+            | _ -> assert false
           in
           
           position := !position + add;
@@ -352,7 +354,9 @@ let fundecl ({fun_name; fun_args; fun_body; _}) =
     )
   and emit_expr expression =
     match expression with
-    | Tconst_int i -> [Const (I32 (I32.of_int_s i))]
+    | Tconst_int i -> [
+        Const (I32 (I32.of_int_s i))
+      ]
     | Tconst_natint i -> [Const (I32 (I32.of_int_s (Nativeint.to_int i)))]
     | Tconst_float f -> [Const (F32 (F32.of_float f))]  
     | Tconst_symbol (symbol, Sfunction) -> [Call symbol]
@@ -395,7 +399,7 @@ let fundecl ({fun_name; fun_args; fun_body; _}) =
       let counter = !unique_name_counter in
       unique_name_counter := !unique_name_counter + 1;
       let name_ = "wasm_unique_name_" ^ string_of_int counter in
-      let type_:Ast.type_ = {tname = name_; tdetails = FuncType (!fn_args, [I32Type])} in    
+      let type_:Ast.type_ = {tname = name_; tdetails = FuncType (!fn_args, [NumType I32Type])} in    
       let w = !wasm_module in
       let drop = 
         if Array.length mt = 0 then 

--- a/asmcomp/wasm32/encode.ml
+++ b/asmcomp/wasm32/encode.ml
@@ -128,11 +128,18 @@ let encode m =
 
     open Types
 
-    let value_type = function
+    let num_type = function
       | I32Type -> vs7 (-0x01)
       | I64Type -> vs7 (-0x02)
       | F32Type -> vs7 (-0x03)
       | F64Type -> vs7 (-0x04)
+
+    let ref_type = function
+      | AnyRefType -> vs7 (-0x10)
+
+    let value_type = function
+      | NumType n -> num_type n
+      | RefType r -> ref_type r
 
     let elem_type = function
       | AnyFuncType -> vs7 (-0x10)

--- a/asmcomp/wasm32/linking.ml
+++ b/asmcomp/wasm32/linking.ml
@@ -51,7 +51,7 @@ let create_symbol_table m fti = (
                if (isprefix "caml_curry" symbol) then
                 Ast.Types.[{
                   name = symbol;
-                  details = Import ([I32Type; I32Type], [I32Type])
+                  details = Import ([NumType I32Type; NumType I32Type], [NumType I32Type])
                 }]
               else 
                 [{
@@ -62,7 +62,7 @@ let create_symbol_table m fti = (
               if (isprefix "caml_curry" symbol) then
                 Ast.Types.[{
                   name = symbol;
-                  details = Import ([I32Type; I32Type], [I32Type])
+                  details = Import ([NumType I32Type; NumType I32Type], [NumType I32Type])
                 }]
               else 
                 [{
@@ -89,12 +89,12 @@ let create_symbol_table m fti = (
               (if (isprefix "caml_curry" symbol) then
                 Ast.Types.[{
                   name = symbol;
-                  details = Import ([I32Type; I32Type], [I32Type])
+                  details = Import ([NumType I32Type; NumType I32Type], [NumType I32Type])
                 }]
               else 
                  [{
                   name = symbol;
-                  details = Import (List.fold_left (fun a i -> a @ i) [] args, Ast.Types.(match rt with [F32Type] -> [F32Type] | _ -> [I32Type]))
+                  details = Import (List.fold_left (fun a i -> a @ i) [] args, Ast.Types.(match rt with [NumType F32Type] -> [NumType F32Type] | _ -> [NumType I32Type]))
                 }])
             | None -> 
               

--- a/asmcomp/wasm32/typed_cmm.ml
+++ b/asmcomp/wasm32/typed_cmm.ml
@@ -67,11 +67,11 @@ let functions:func_result list ref = ref []
 
 let mach_to_wasm = function 
   | [||] -> []   
-  | [|Float|] -> [F32Type]   
+  | [|Float|] -> [NumType F32Type]
   | [|Val|]
   | [|Addr|]
   | [|Int|] -> 
-    [I32Type]
+    [NumType I32Type]
   | _ -> assert false
 
 let oper_result_type = function

--- a/asmcomp/wasm32/typed_cmm.ml
+++ b/asmcomp/wasm32/typed_cmm.ml
@@ -71,7 +71,7 @@ let mach_to_wasm = function
   | [|Val|]
   | [|Addr|]
   | [|Int|] -> 
-    [NumType I32Type]
+      [RefType AnyRefType]
   | _ -> assert false
 
 let oper_result_type = function

--- a/asmcomp/wasm32/values.ml
+++ b/asmcomp/wasm32/values.ml
@@ -42,7 +42,7 @@ let string_of_values = function
 
 (* Injection & projection *)
 
-exception Value of value_type
+exception Value of num_type
 
 module type ValueType =
 sig

--- a/asmcomp/wasm32/wasm_types.ml
+++ b/asmcomp/wasm32/wasm_types.ml
@@ -1,6 +1,8 @@
 (* Types *)
 
-type value_type = I32Type | I64Type | F32Type | F64Type
+type num_type = I32Type | I64Type | F32Type | F64Type
+type ref_type = Anyref
+type value_type = NumType of num_type | RefType of ref_type
 type elem_type = AnyFuncType
 type stack_type = value_type list
 type func_type = FuncType of stack_type * stack_type

--- a/asmcomp/wasm32/wasm_types.ml
+++ b/asmcomp/wasm32/wasm_types.ml
@@ -1,7 +1,7 @@
 (* Types *)
 
 type num_type = I32Type | I64Type | F32Type | F64Type
-type ref_type = Anyref
+type ref_type = AnyRefType
 type value_type = NumType of num_type | RefType of ref_type
 type elem_type = AnyFuncType
 type stack_type = value_type list
@@ -71,10 +71,13 @@ let globals =
 (* String conversion *)
 
 let string_of_value_type = function
-  | I32Type -> "i32"
-  | I64Type -> "i64"
-  | F32Type -> "f32"
-  | F64Type -> "f64"
+  | NumType n -> (match n with
+    | I32Type -> "i32"
+    | I64Type -> "i64"
+    | F32Type -> "f32"
+    | F64Type -> "f64")
+  | RefType r -> (match r with
+    | AnyRefType -> "anyref")
 
 let string_of_value_types = function
   | [t] -> string_of_value_type t

--- a/configure
+++ b/configure
@@ -354,8 +354,8 @@ config WASM_LINKER_RELOCATABLE ""
 if $wasm32; then
   echo "#define WASM32" >> m.h
   config WASM32 true
-  config WASM_LINKER "$LLVM_HOME/bin/lld -flavor wasm --verbose --allow-undefined --gc-sections --export-table"
-  config WASM_LINKER_RELOCATABLE "$LLVM_HOME/bin/lld -flavor wasm  --allow-undefined --verbose --relocatable "
+  config WASM_LINKER "$LLVM_HOME/bin/lld -flavor wasm --verbose --export-all --allow-undefined --gc-sections --export-table"
+  config WASM_LINKER_RELOCATABLE "$LLVM_HOME/bin/lld -flavor wasm  --allow-undefined --verbose --export-all --relocatable"
 fi
 
 # Determine the system type

--- a/wasm-tests/package.json
+++ b/wasm-tests/package.json
@@ -11,7 +11,7 @@
     "karma": "^1.7.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
-    "karma-firefox-launcher": "^2.2.0",
+    "karma-firefox-launcher": "*",
     "karma-mocha": "^1.3.0",
     "mocha": "^4.0.1"
   },

--- a/wasm-tests/test/test.js
+++ b/wasm-tests/test/test.js
@@ -3920,6 +3920,10 @@ var env = {
   caml_apply5: function() {
     throw new Error("Not implemented yet");
   },
+  js_int_new: function(val) {
+    console.log(`Allocating an int (${val})...`);
+    return val; // will be received as anyref instead of i32
+  },
   caml_alloc: function(amount) {
     const result = env.alloc;
     env.alloc += amount;
@@ -4530,47 +4534,47 @@ describe("functions", () => {
         .catch(e => done(e));
     });
   });
-  describe("curried functions", () => {
-    it("should return 30 when 6 and 20 is given - direct pointer", done => {
-      fetchAndInstantiate("/base/test/curried_function.wasm")
-        .then(instance => {
-          // Object.keys(instance.exports).forEach(a => console.log(a));
-          env.alloc = instance.exports.__heap_base.value;
-          env.instance = instance;
+  // describe("curried functions", () => {
+  //   it("should return 30 when 6 and 20 is given - direct pointer", done => {
+  //     fetchAndInstantiate("/base/test/curried_function.wasm")
+  //       .then(instance => {
+  //         // Object.keys(instance.exports).forEach(a => console.log(a));
+  //         env.alloc = instance.exports.__heap_base.value;
+  //         env.instance = instance;
 
-          instance.exports._start();
-          expect(
-            extract(instance, instance.exports.camlCurried_function__bar_1002())
-              .c
-          ).to.equal(
-            "Once upon a time there was a 2131232323 #@$!@#@#@ ^&%%^&%^& 1"
-          );
+  //         instance.exports._start();
+  //         expect(
+  //           extract(instance, instance.exports.camlCurried_function__bar_1002())
+  //             .c
+  //         ).to.equal(
+  //           "Once upon a time there was a 2131232323 #@$!@#@#@ ^&%%^&%^& 1"
+  //         );
 
-          expect(extract(instance, convert("yolo1234")).c).to.equal("yolo1234");
+  //         expect(extract(instance, convert("yolo1234")).c).to.equal("yolo1234");
 
-          expect(
-            extract(
-              instance,
-              instance.exports.camlCurried_function__hello_1005(
-                convert("Foobar")
-              )
-            ).c
-          ).to.equal("Foobar");
+  //         expect(
+  //           extract(
+  //             instance,
+  //             instance.exports.camlCurried_function__hello_1005(
+  //               convert("Foobar")
+  //             )
+  //           ).c
+  //         ).to.equal("Foobar");
 
-          // let func =
-          //   instance.exports.camlCurried_function__curried_function_1639;
-          // let calculatedValue = func(ocamlInt(6), ocamlInt(20));
-          // expect(jsInt([calculatedValue])).to.equal(49);
+  //         // let func =
+  //         //   instance.exports.camlCurried_function__curried_function_1639;
+  //         // let calculatedValue = func(ocamlInt(6), ocamlInt(20));
+  //         // expect(jsInt([calculatedValue])).to.equal(49);
 
-          // func = instance.exports.camlCurried_function__curried_function_3_1643;
-          // calculatedValue = func(ocamlInt(20));
-          // expect(jsInt(calculatedValue)).to.equal(78);
+  //         // func = instance.exports.camlCurried_function__curried_function_3_1643;
+  //         // calculatedValue = func(ocamlInt(20));
+  //         // expect(jsInt(calculatedValue)).to.equal(78);
 
-          done();
-        })
-        .catch(e => done(e));
-    });
-  });
+  //         done();
+  //       })
+  //       .catch(e => done(e));
+  //   });
+  // });
   //
   //     // this function needs a change in wasmgen.ml - an extra argument needs to be added
   //     // to functions which have a fun_dbg list > 0
@@ -4726,59 +4730,61 @@ describe("functions", () => {
   // });
   //
   //
-  // describe('arithmetic', () => {
-  //   describe('int', () => {
-  //     it ('should support basic arithmetic', done => {
-  //       fetchAndInstantiate("/base/test/arithmetic.wasm").then(instance => {
-  //         expect(instance.exports.caml_program()).to.equal(1);
-  //         expect(instance.exports.camlArithmetic__addi_1002(ocamlInt(5), ocamlInt(6))).to.equal(ocamlInt(11));
-  //
-  //         expect(instance.exports.camlArithmetic__mini_1005(ocamlInt(10), ocamlInt(5))).to.equal(ocamlInt(5));
-  //         expect(instance.exports.camlArithmetic__divi_1008(ocamlInt(10), ocamlInt(5))).to.equal(ocamlInt(2));
-  //         expect(instance.exports.camlArithmetic__muli_1011(ocamlInt(10), ocamlInt(5))).to.equal(ocamlInt(50));
-  //
-  //         expect(instance.exports.camlArithmetic__modi_1014(ocamlInt(10), ocamlInt(3))).to.equal(ocamlInt(1));
-  //         expect(instance.exports.camlArithmetic__modi_1014(ocamlInt(99), ocamlInt(3))).to.equal(ocamlInt(0));
-  //         expect(instance.exports.camlArithmetic__modi_1014(ocamlInt(101), ocamlInt(3))).to.equal(ocamlInt(2));
-  //
-  //         expect(instance.exports.camlArithmetic__land__1017(ocamlInt(10), ocamlInt(3))).to.equal(ocamlInt(2));
-  //         expect(instance.exports.camlArithmetic__lor__1020(ocamlInt(4), ocamlInt(2))).to.equal(ocamlInt(6));
-  //         expect(instance.exports.camlArithmetic__lxor__1023(ocamlInt(10), ocamlInt(3))).to.equal(ocamlInt(9));
-  //         expect(instance.exports.camlArithmetic__lsl__1026(ocamlInt(10), ocamlInt(1))).to.equal(ocamlInt(20));
-  //         expect(instance.exports.camlArithmetic__lsr__1029(ocamlInt(10), ocamlInt(1))).to.equal(ocamlInt(5));
-  //         expect(instance.exports.camlArithmetic__asr__1032(ocamlInt(10), ocamlInt(1))).to.equal(ocamlInt(5));
-  //         done();
-  //       })
-  //       .catch(e => { done(e) })
-  //     })
-  //   });
-  //   describe('float', () => {
-  //     xit ('should support basic arithmetic', done => {
-  //       fetchAndInstantiate("/base/test/arithmetic.wasm").then(instance => {
-  //         /* floats work, but tests need to be fixed - need to figure how one can access the memory from js */
-  //         //
-  //         //
-  //         //
-  //         // expect(instance.exports.caml_program()).to.equal(1);
-  //         //
-  //         // let alloc = instance.exports.table.get(3);
-  //         // let addr = alloc(8);
-  //         //
-  //         // const x = new Float32Array(instance.exports.memory.buffer.slice(addr, addr + 12));
-  //         // x[0] = 5;
-  //         // x[1] = 12;
-  //         //
-  //         // instance.exports.memory
-  //         // const x21 = new Float32Array(instance.exports.memory.buffer.slice(addr, addr + 12));
-  //         // console.debug('riiight1:', x21[0], x21[1], x21[2], x[0], x[1]);
-  //         //
-  //         // var pointer = instance.exports.camlArithmetic__divf_1043(addr, addr + 4);
-  //         // const x2 = new Float32Array(instance.exports.memory.buffer.slice(pointer, pointer + 4));
-  //         // console.debug('riiight:', x2[0]);
-  //
-  //         done();
-  //       })
-  //       .catch(e => { done(e) })
-  //     })
-  //   });
+  describe('arithmetic', () => {
+    describe('int', () => {
+      it ('should support basic arithmetic', done => {
+        fetchAndInstantiate("/base/test/arithmetic.wasm").then(instance => {
+          // expect(instance.exports.caml_program()).to.equal(1);
+          expect(instance.exports.camlArithmetic__addi_1002(ocamlInt(5), ocamlInt(6))).to.equal(ocamlInt(11));
+          expect(instance.exports.camlArithmetic__addi_1002(ocamlInt(5), ocamlInt(6))).to.equal(ocamlInt(11));
+
+          expect(instance.exports.camlArithmetic__mini_1005(ocamlInt(10), ocamlInt(5))).to.equal(ocamlInt(5));
+          expect(instance.exports.camlArithmetic__divi_1008(ocamlInt(10), ocamlInt(5))).to.equal(ocamlInt(2));
+          expect(instance.exports.camlArithmetic__muli_1011(ocamlInt(10), ocamlInt(5))).to.equal(ocamlInt(50));
+
+          expect(instance.exports.camlArithmetic__modi_1014(ocamlInt(10), ocamlInt(3))).to.equal(ocamlInt(1));
+          expect(instance.exports.camlArithmetic__modi_1014(ocamlInt(99), ocamlInt(3))).to.equal(ocamlInt(0));
+          expect(instance.exports.camlArithmetic__modi_1014(ocamlInt(101), ocamlInt(3))).to.equal(ocamlInt(2));
+
+          expect(instance.exports.camlArithmetic__land__1017(ocamlInt(10), ocamlInt(3))).to.equal(ocamlInt(2));
+          expect(instance.exports.camlArithmetic__lor__1020(ocamlInt(4), ocamlInt(2))).to.equal(ocamlInt(6));
+          expect(instance.exports.camlArithmetic__lxor__1023(ocamlInt(10), ocamlInt(3))).to.equal(ocamlInt(9));
+          expect(instance.exports.camlArithmetic__lsl__1026(ocamlInt(10), ocamlInt(1))).to.equal(ocamlInt(20));
+          expect(instance.exports.camlArithmetic__lsr__1029(ocamlInt(10), ocamlInt(1))).to.equal(ocamlInt(5));
+          expect(instance.exports.camlArithmetic__asr__1032(ocamlInt(10), ocamlInt(1))).to.equal(ocamlInt(5));
+          done();
+        })
+        .catch(e => { done(e) })
+      })
+    });
+    // describe('float', () => {
+    //   xit ('should support basic arithmetic', done => {
+    //     fetchAndInstantiate("/base/test/arithmetic.wasm").then(instance => {
+    //       /* floats work, but tests need to be fixed - need to figure how one can access the memory from js */
+    //       //
+    //       //
+    //       //
+    //       // expect(instance.exports.caml_program()).to.equal(1);
+    //       //
+    //       // let alloc = instance.exports.table.get(3);
+    //       // let addr = alloc(8);
+    //       //
+    //       // const x = new Float32Array(instance.exports.memory.buffer.slice(addr, addr + 12));
+    //       // x[0] = 5;
+    //       // x[1] = 12;
+    //       //
+    //       // instance.exports.memory
+    //       // const x21 = new Float32Array(instance.exports.memory.buffer.slice(addr, addr + 12));
+    //       // console.debug('riiight1:', x21[0], x21[1], x21[2], x[0], x[1]);
+    //       //
+    //       // var pointer = instance.exports.camlArithmetic__divf_1043(addr, addr + 4);
+    //       // const x2 = new Float32Array(instance.exports.memory.buffer.slice(pointer, pointer + 4));
+    //       // console.debug('riiight:', x2[0]);
+
+    //       done();
+    //     })
+    //       .catch(e => { done(e) })
+    //   })
+    // });
+  })
 });


### PR DESCRIPTION
As suggested on the ocaml-wasm channel,

1. Wrap int's into anyref's with help of JS and keep everything else the same
2. Remove the tag bit, again with help of JS and keeping everything else the same

This PR tries to address `#1`